### PR TITLE
Building out composer file that contains basic wordpress install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 .idea/
 node_modules/
+vendor/
 *.log

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "elementius/wordpressium",
     "description": "An opinionated Wordpress base installer setup",
-    "keywords" : ["wordpress"],
+    "keywords": [
+        "wordpress"
+    ],
     "type": "project",
     "license": "GPL-3.0+",
     "authors": [
@@ -19,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "johnpbloch/wordpress": "*",
+        "johnpbloch/wordpress": "^4.8",
         "lkwdwrd/wp-muplugin-loader": "^1.0",
         "vlucas/phpdotenv": "^2.4"
     },
@@ -27,5 +29,19 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true
+    },
+    "extra": {
+        "wordpress-install-dir": "public/app",
+        "installer-paths": {
+            "public/plugins/{$name}/": [
+                "type:wordpress-plugin"
+            ],
+            "public/themes/{$name}/": [
+                "type:wordpress-theme"
+            ],
+            "public/plugins/required/{$name}/": [
+                "type:wordpress-muplugin"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "elementius/wordpressium",
-    "description": "An opinionated Wordpress base installer setup",
+    "description": "An opinionated Wordpress base project setup",
     "keywords": [
         "wordpress"
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "elementius/wordpressium",
+    "description": "An opinionated Wordpress base installer setup",
+    "keywords" : ["wordpress"],
+    "type": "project",
+    "license": "GPL-3.0+",
+    "authors": [
+        {
+            "name": "Jamieson Roberts",
+            "email": "hello@jamiesonroberts.ca"
+        }
+    ],
+    "minimum-stability": "stable",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://wpackagist.org"
+        }
+    ],
+    "require": {
+        "php": ">=7.0.0",
+        "johnpbloch/wordpress": "*",
+        "lkwdwrd/wp-muplugin-loader": "^1.0",
+        "vlucas/phpdotenv": "^2.4"
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "optimize-autoloader": true
+    }
+}


### PR DESCRIPTION
This setups up the following for the composer file

1. Basic project information/composer requirements  
2. Correct dependancies for...
- Wordpress install (via long standing auto publish git project, 
- PHPDotEnv
- Composer package to handle installation of wordpress plugins as "must-use"
3. Sets up basic composer install folder structure for Wordpress themes and plugins
4. Includes WPackagist as a source to be able to install Wordpress themes and plugins as a composer install